### PR TITLE
Refine origins rule

### DIFF
--- a/src/legality.rs
+++ b/src/legality.rs
@@ -1,6 +1,6 @@
 use chess::Board;
 
-use crate::rules::{MaterialRule, OriginsRule, Rule, State, SteadyRule};
+use crate::rules::{MaterialRule, OriginsRule, RefineOriginsRule, Rule, State, SteadyRule};
 
 /// Initialize all the available rules on the given board.
 fn init_rules(board: &Board) -> Vec<Box<dyn Rule>> {
@@ -8,6 +8,7 @@ fn init_rules(board: &Board) -> Vec<Box<dyn Rule>> {
         Box::new(MaterialRule::new(board)),
         Box::new(SteadyRule::new(board)),
         Box::new(OriginsRule::new(board)),
+        Box::new(RefineOriginsRule::new(board)),
     ]
 }
 

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -122,3 +122,6 @@ pub use steady::*;
 
 mod origins;
 pub use origins::*;
+
+mod refine_origins;
+pub use refine_origins::*;

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -103,10 +103,7 @@ impl fmt::Display for State {
         writeln!(f, "FEN: {}\n", self.board,)?;
         writeln!(f, "steady:\n{}", self.steady.reverse_colors())?;
         writeln!(f, "origins (cnt: {}):\n", self.origins.1)?;
-        for square in *self.board.combined() {
-            if self.origins(square).popcnt() == 1 {
-                continue;
-            }
+        for square in *self.board.combined() & !self.steady {
             write!(f, "  {} <- [", square)?;
             for origin in self.origins(square) {
                 write!(f, "{},", origin)?;

--- a/src/rules/origins.rs
+++ b/src/rules/origins.rs
@@ -1,16 +1,18 @@
 //! Origins rule.
+//!
+//! A simple rule that refines the set of origins based on the initial
+//! position of chess.
+//! Queens, rooks, bishops and knights may also come from their relative 2nd
+//! rank, as they may be promoted.
 
-use chess::{BitBoard, Board, Color, Piece, EMPTY};
+use chess::{BitBoard, Board, Piece, Square, EMPTY};
 
 use super::{Rule, State};
+use crate::utils::square_color;
 
-/// A simple rule that refines the set of origins based on the initial
-/// conditions of chess. Queens, rooks, bishops and knights may also come from
-/// their relative 2nd rank, as they may be promoted.
-///
-/// This rule depends solely on the steady pieces, so we keep track of the state
-/// of steady pieces the last time this rule was applied to see if we should
-/// apply it again.
+// This rule depends solely on the steady pieces, so we keep track of the state
+// of steady pieces the last time this rule was applied to see if we should
+// apply it again.
 #[derive(Debug)]
 pub struct OriginsRule {
     steady: BitBoard,
@@ -37,7 +39,8 @@ impl Rule for OriginsRule {
         for square in *state.board.combined() & !state.steady {
             let square_origins = state.origins(square)
                 & !state.steady
-                & piece_origins(state.piece_type_on(square), state.piece_color_on(square));
+                & COLOR_ORIGINS[state.piece_color_on(square).to_index()]
+                & origins_of_piece_on(state.piece_type_on(square), square);
             progress = progress || (state.origins(square) != square_origins);
             state.origins.0[square.to_index()] = square_origins;
         }
@@ -51,86 +54,140 @@ impl Rule for OriginsRule {
     }
 }
 
-const KING_ORIGINS: [BitBoard; 2] = [BitBoard(16), BitBoard(1152921504606846976)];
-const ROOK_ORIGINS: [BitBoard; 2] = [BitBoard(65409), BitBoard(9367205749953921024)];
-const PAWN_ORIGINS: [BitBoard; 2] = [BitBoard(65280), BitBoard(71776119061217280)];
-const QUEEN_ORIGINS: [BitBoard; 2] = [BitBoard(65288), BitBoard(648236871364640768)];
-const BISHOP_ORIGINS: [BitBoard; 2] = [BitBoard(65316), BitBoard(2665849504426622976)];
-const KNIGHT_ORIGINS: [BitBoard; 2] = [BitBoard(65346), BitBoard(4827577325564461056)];
-
-/// The candidate squares from which a piece of the given type and color may
-/// have started the game.
+/// The candidate squares from which a piece of the given type which is
+/// currently on the given square may have started the game.
 #[inline]
-fn piece_origins(piece: Piece, color: Color) -> BitBoard {
+fn origins_of_piece_on(piece: Piece, square: Square) -> BitBoard {
     match piece {
-        Piece::King => KING_ORIGINS[color.to_index()],
-        Piece::Queen => QUEEN_ORIGINS[color.to_index()],
-        Piece::Rook => ROOK_ORIGINS[color.to_index()],
-        Piece::Bishop => BISHOP_ORIGINS[color.to_index()],
-        Piece::Knight => KNIGHT_ORIGINS[color.to_index()],
-        Piece::Pawn => PAWN_ORIGINS[color.to_index()],
+        Piece::King => KING_ORIGINS,
+        Piece::Queen => QUEEN_ORIGINS,
+        Piece::Rook => ROOK_ORIGINS,
+        Piece::Bishop => BISHOP_ORIGINS[square_color(square).to_index()],
+        Piece::Knight => KNIGHT_ORIGINS,
+        Piece::Pawn => PAWN_ORIGINS[square.to_index()],
     }
 }
+
+const COLOR_ORIGINS: [BitBoard; 2] = [
+    BitBoard(65535),                // 1st & 2nd ranks
+    BitBoard(18446462598732840960), // 7th & 8th ranks
+];
+const KING_ORIGINS: BitBoard = BitBoard(1152921504606846992); // E1, E8
+const QUEEN_ORIGINS: BitBoard = BitBoard(648236871364706056); // D1, D8, 2nd & 7th ranks
+const ROOK_ORIGINS: BitBoard = BitBoard(9367205749953986433); // A1, H1, A8, H8, 2nd & 7th ranks
+const KNIGHT_ORIGINS: BitBoard = BitBoard(4827577325564526402); // B1, G1, B8, G8, 2nd & 7th ranks
+const BISHOP_ORIGINS: [BitBoard; 2] = [
+    BitBoard(360006495212994336),  // F1, C8, 2nd & 7th ranks
+    BitBoard(2377619128274976516), // C1, F8, 2nd & 7th ranks
+];
+const PAWN_ORIGINS: [BitBoard; 64] = [
+    BitBoard(0),                 // A1: N/A
+    BitBoard(0),                 // B1: N/A
+    BitBoard(0),                 // C1: N/A
+    BitBoard(0),                 // D1: N/A
+    BitBoard(0),                 // E1: N/A
+    BitBoard(0),                 // F1: N/A
+    BitBoard(0),                 // G1: N/A
+    BitBoard(0),                 // H1: N/A
+    BitBoard(17732923532771584), // A2: A2, A7, B7, C7, D7, E7, F7
+    BitBoard(35747322042253824), // B2: B2, A7, B7, C7, D7, E7, F7, G7
+    BitBoard(71776119061218304), // C2: C2, A7, B7, C7, D7, E7, F7, G7, H7
+    BitBoard(71776119061219328), // D2: D2, A7, B7, C7, D7, E7, F7, G7, H7
+    BitBoard(71776119061221376), // E2: E2, A7, B7, C7, D7, E7, F7, G7, H7
+    BitBoard(71776119061225472), // F2: F2, A7, B7, C7, D7, E7, F7, G7, H7
+    BitBoard(71494644084523008), // G2: G2, B7, C7, D7, E7, F7, G7, H7
+    BitBoard(70931694131118080), // H2: H2, C7, D7, E7, F7, G7, H7
+    BitBoard(8725724278031104),  // A3: A2, B2, A7, B7, C7, D7, E7
+    BitBoard(17732923532773120), // B3: A2, B2, C2, A7, B7, C7, D7, E7, F7
+    BitBoard(35747322042256896), // C3: B2, C2, D2, A7, B7, C7, D7, E7, F7, G7
+    BitBoard(71776119061224448), // D3: C2, D2, E2, A7, B7, C7, D7, E7, F7, G7, H7
+    BitBoard(71776119061231616), // E3: D2, E2, F2, A7, B7, C7, D7, E7, F7, G7, H7
+    BitBoard(71494644084535296), // F3: E2, F2, G2, B7, C7, D7, E7, F7, G7, H7
+    BitBoard(70931694131142656), // G3: F2, G2, H2, C7, D7, E7, F7, G7, H7
+    BitBoard(69805794224291840), // H3: G2, H2, D7, E7, F7, G7, H7
+    BitBoard(4222124650661632),  // A4: A2, B2, C2, A7, B7, C7, D7
+    BitBoard(8725724278034176),  // B4: A2, B2, C2, D2, A7, B7, C7, D7, E7
+    BitBoard(17732923532779264), // C4: A2, B2, C2, D2, E2, A7, B7, C7, D7, E7, F7
+    BitBoard(35747322042269184), // D4: B2, C2, D2, E2, F2, A7, B7, C7, D7, E7, F7, G7
+    BitBoard(71494644084538368), // E4: C2, D2, E2, F2, G2, B7, C7, D7, E7, F7, G7, H7
+    BitBoard(70931694131148800), // F4: D2, E2, F2, G2, H2, C7, D7, E7, F7, G7, H7
+    BitBoard(69805794224304128), // G4: E2, F2, G2, H2, D7, E7, F7, G7, H7
+    BitBoard(67553994410614784), // H4: F2, G2, H2, E7, F7, G7, H7
+    BitBoard(1970324836978432),  // A5: A2, B2, C2, D2, A7, B7, C7
+    BitBoard(4222124650667776),  // B5: A2, B2, C2, D2, E2, A7, B7, C7, D7
+    BitBoard(8725724278046464),  // C5: A2, B2, C2, D2, E2, F2, A7, B7, C7, D7, E7
+    BitBoard(17451448556093184), // D5: A2, B2, C2, D2, E2, F2, G2, B7, C7, D7, E7, F7
+    BitBoard(34902897112186368), // E5: B2, C2, D2, E2, F2, G2, H2, C7, D7, E7, F7, G7
+    BitBoard(69805794224307200), // F5: C2, D2, E2, F2, G2, H2, D7, E7, F7, G7, H7
+    BitBoard(67553994410620928), // G5: D2, E2, F2, G2, H2, E7, F7, G7, H7
+    BitBoard(63050394783248384), // H5: E2, F2, G2, H2, F7, G7, H7
+    BitBoard(844424930139904),   // A6: A2, B2, C2, D2, E2, A7, B7
+    BitBoard(1970324836990720),  // B6: A2, B2, C2, D2, E2, F2, A7, B7, C7
+    BitBoard(3940649673981696),  // C6: A2, B2, C2, D2, E2, F2, G2, B7, C7, D7
+    BitBoard(7881299347963648),  // D6: A2, B2, C2, D2, E2, F2, G2, H2, C7, D7, E7
+    BitBoard(15762598695862016), // E6: A2, B2, C2, D2, E2, F2, G2, H2, D7, E7, F7
+    BitBoard(31525197391658496), // F6: B2, C2, D2, E2, F2, G2, H2, E7, F7, G7
+    BitBoard(63050394783251456), // G6: C2, D2, E2, F2, G2, H2, F7, G7, H7
+    BitBoard(54043195528509440), // H6: D2, E2, F2, G2, H2, G7, H7
+    BitBoard(281474976726784),   // A7: A2, B2, C2, D2, E2, F2, A7
+    BitBoard(562949953453824),   // B7: A2, B2, C2, D2, E2, F2, G2, B7
+    BitBoard(1125899906907904),  // C7: A2, B2, C2, D2, E2, F2, G2, H2, C7
+    BitBoard(2251799813750528),  // D7: A2, B2, C2, D2, E2, F2, G2, H2, D7
+    BitBoard(4503599627435776),  // E7: A2, B2, C2, D2, E2, F2, G2, H2, E7
+    BitBoard(9007199254806272),  // F7: A2, B2, C2, D2, E2, F2, G2, H2, F7
+    BitBoard(18014398509547008), // G7: B2, C2, D2, E2, F2, G2, H2, G7
+    BitBoard(36028797019028480), // H7: C2, D2, E2, F2, G2, H2, H7
+    BitBoard(0),                 // A8: N/A
+    BitBoard(0),                 // B8: N/A
+    BitBoard(0),                 // C8: N/A
+    BitBoard(0),                 // D8: N/A
+    BitBoard(0),                 // E8: N/A
+    BitBoard(0),                 // F8: N/A
+    BitBoard(0),                 // G8: N/A
+    BitBoard(0),                 // H8: N/A
+];
 
 #[cfg(test)]
 mod tests {
     use chess::{get_rank, Rank};
 
-    use crate::utils::{
-        bitboard_of_squares, A1, A8, B1, B8, C1, C8, D1, D8, E1, E8, F1, F8, G1, G8, H1, H8,
-    };
-
     use super::*;
+    use crate::utils::*;
 
     #[test]
-    fn test_piece_origins() {
+    fn test_origins_of_piece_on() {
+        let pawn_ranks = get_rank(Rank::Second) | get_rank(Rank::Seventh);
         assert_eq!(
-            piece_origins(Piece::King, Color::White),
-            BitBoard::from_square(E1)
+            origins_of_piece_on(Piece::King, A1),
+            bitboard_of_squares(&[E1, E8])
         );
         assert_eq!(
-            piece_origins(Piece::Queen, Color::White),
-            get_rank(Rank::Second) | BitBoard::from_square(D1)
+            origins_of_piece_on(Piece::Queen, D1),
+            bitboard_of_squares(&[D1, D8]) | pawn_ranks
         );
         assert_eq!(
-            piece_origins(Piece::Rook, Color::White),
-            get_rank(Rank::Second) | bitboard_of_squares(&[A1, H1])
+            origins_of_piece_on(Piece::Rook, B1),
+            bitboard_of_squares(&[A1, H1, A8, H8]) | pawn_ranks
         );
         assert_eq!(
-            piece_origins(Piece::Bishop, Color::White),
-            get_rank(Rank::Second) | bitboard_of_squares(&[C1, F1])
+            origins_of_piece_on(Piece::Knight, H8),
+            bitboard_of_squares(&[B1, G1, B8, G8]) | pawn_ranks
         );
         assert_eq!(
-            piece_origins(Piece::Knight, Color::White),
-            get_rank(Rank::Second) | bitboard_of_squares(&[B1, G1])
+            origins_of_piece_on(Piece::Bishop, B1),
+            bitboard_of_squares(&[F1, C8]) | pawn_ranks
         );
         assert_eq!(
-            piece_origins(Piece::Pawn, Color::White),
-            get_rank(Rank::Second)
+            origins_of_piece_on(Piece::Bishop, A1),
+            bitboard_of_squares(&[C1, F8]) | pawn_ranks
         );
         assert_eq!(
-            piece_origins(Piece::King, Color::Black),
-            BitBoard::from_square(E8)
+            origins_of_piece_on(Piece::Pawn, H4),
+            bitboard_of_squares(&[F2, G2, H2, E7, F7, G7, H7])
         );
         assert_eq!(
-            piece_origins(Piece::Queen, Color::Black),
-            get_rank(Rank::Seventh) | BitBoard::from_square(D8)
-        );
-        assert_eq!(
-            piece_origins(Piece::Rook, Color::Black),
-            get_rank(Rank::Seventh) | bitboard_of_squares(&[A8, H8])
-        );
-        assert_eq!(
-            piece_origins(Piece::Bishop, Color::Black),
-            get_rank(Rank::Seventh) | bitboard_of_squares(&[C8, F8])
-        );
-        assert_eq!(
-            piece_origins(Piece::Knight, Color::Black),
-            get_rank(Rank::Seventh) | bitboard_of_squares(&[B8, G8])
-        );
-        assert_eq!(
-            piece_origins(Piece::Pawn, Color::Black),
-            get_rank(Rank::Seventh)
+            origins_of_piece_on(Piece::Pawn, C6),
+            bitboard_of_squares(&[A2, B2, C2, D2, E2, F2, G2, B7, C7, D7])
         );
     }
 }

--- a/src/rules/refine_origins.rs
+++ b/src/rules/refine_origins.rs
@@ -1,0 +1,57 @@
+//! Refine origins rule.
+//!
+//! This rule exploits the fact that if there is a group of k pieces with k
+//! combined candidate origins, those origins cannot be origins of any other
+//! piece.
+
+use chess::{Board, ALL_COLORS};
+
+use super::{Counter, Rule, State};
+use crate::utils::find_k_group;
+
+#[derive(Debug)]
+pub struct RefineOriginsRule {
+    origins_counter: Counter,
+}
+
+impl Rule for RefineOriginsRule {
+    fn new(_board: &Board) -> Self {
+        RefineOriginsRule { origins_counter: 0 }
+    }
+
+    fn is_applicable(&self, state: &State) -> bool {
+        self.origins_counter != state.origins.1 || self.origins_counter == 0
+    }
+
+    fn apply(&mut self, state: &mut State) {
+        let mut progress = false;
+
+        for color in ALL_COLORS {
+            // We iterate up to k = 10, since that is the maximum number of candidate
+            // origins of any piece after applying the origins rule.
+            for k in 1..=10 {
+                let mut iter = *state.board.color_combined(color);
+                loop {
+                    match find_k_group(k, &state.origins.0, iter) {
+                        None => break,
+                        Some((group, remaining)) => {
+                            iter = remaining;
+                            for square in iter {
+                                let square_origins = state.origins(square) & !group;
+                                progress |= state.origins(square) != square_origins;
+                                state.origins.0[square.to_index()] = square_origins;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // update the rule state and report any progress
+        self.origins_counter = state.origins.1;
+        if progress {
+            state.origins.1 += 1;
+            state.progress = true;
+        }
+    }
+}

--- a/src/rules/steady.rs
+++ b/src/rules/steady.rs
@@ -1,20 +1,17 @@
 //! Steady rule.
+//!
+//! A rule that updates the information on steady pieces: pieces that have
+//! certainly never moved and are still on their starting square.
+//! Steady pieces can be identified through the castling information or by
+//! realizing that a piece is limited in movement by other steady pieces (e.g.
+//! pawns on their relative 2nd rank are steady, thus a white bishop on c1 is
+//! steady if there are white pawns on b2 and d2).
 
 use chess::{BitBoard, Board, CastleRights, Piece, ALL_COLORS, EMPTY};
-use lazy_static::lazy_static;
 
 use super::{Rule, State};
-use crate::utils::{
-    bitboard_of_squares, predecessors, C1, C2, C7, C8, D1, D2, D7, D8, E1, E2, E7, E8, F1, F2, F7,
-    F8,
-};
+use crate::utils::predecessors;
 
-/// A rule that updates the information on steady pieces: pieces that have
-/// certainly never moved and are still on their starting square.
-/// Steady pieces can be identified through the castling information or by
-/// realizing that a piece is limited in movement by other steady pieces (e.g.
-/// pawns on their relative 2nd rank are steady, thus a white bishop on c1 is
-/// steady if there are white pawns on b2 and d2).
 #[derive(Debug)]
 pub struct SteadyRule {
     steady: BitBoard,
@@ -38,17 +35,6 @@ impl Rule for SteadyRule {
             state.progress = true;
         }
     }
-}
-
-lazy_static! {
-    static ref MARRIAGE_COUPLE: [BitBoard; 2] = [
-        bitboard_of_squares(&[D1, E1]),
-        bitboard_of_squares(&[D8, E8]),
-    ];
-    static ref MARRIAGE_CAGE: [BitBoard; 2] = [
-        bitboard_of_squares(&[C1, C2, D2, E2, F2, F1,]),
-        bitboard_of_squares(&[C8, C7, D7, E7, F7, F8,]),
-    ];
 }
 
 /// Gets a `Board`` and a `BitBoard` containing the information on squares
@@ -92,12 +78,21 @@ fn steady_pieces(board: &Board, steady: &BitBoard) -> BitBoard {
     steady
 }
 
+const MARRIAGE_COUPLE: [BitBoard; 2] = [
+    BitBoard(24),                  // D1, E1
+    BitBoard(1729382256910270464), // D8, E8
+];
+const MARRIAGE_CAGE: [BitBoard; 2] = [
+    BitBoard(15396),               // C1, C2, D2, E2, F2, F1
+    BitBoard(2610961883968045056), // C8, C7, D7, E7, F7, F8
+];
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
 
     use super::*;
-    use crate::utils::{A1, A6, A8, B2, B7, B8, C6, F3, G1, G2, G7, H1, H2, H3};
+    use crate::utils::*;
 
     #[test]
     fn test_steady_pieces() {

--- a/src/utils/k_groups.rs
+++ b/src/utils/k_groups.rs
@@ -1,0 +1,101 @@
+//! We say a set of at least k sets is a k-group iff their union results
+//! in at most k elements.
+//!
+//! The notion of k-group is a powerful concept which is the basis of rules like
+//! `refine_origins`.
+
+use chess::{BitBoard, EMPTY};
+
+/// On input `k`, an array of sets (64 sets, one for each square on the board)
+/// and a set of (square) indices given in the form of `BitBoard`, this function
+/// finds a `k`-group and returns its union set and a set of the indices that
+/// *do not* form the k-group.
+///
+/// This function returns `None` iff no k-group exists in the given sets
+/// filtered by the given indices.
+pub fn find_k_group(
+    k: usize,
+    sets: &[BitBoard; 64],
+    indices: BitBoard,
+) -> Option<(BitBoard, BitBoard)> {
+    find_k_group_recursively(k, sets, indices, (EMPTY, 0))
+}
+
+fn find_k_group_recursively(
+    k: usize,
+    sets: &[BitBoard; 64],
+
+    remaining_indices: BitBoard,
+    group: (BitBoard, usize),
+) -> Option<(BitBoard, BitBoard)> {
+    if group.0.popcnt() as usize > k {
+        return None;
+    }
+    if group.1 >= k {
+        return Some((group.0, remaining_indices));
+    }
+    let mut remaining = remaining_indices.into_iter();
+    if let Some(square) = remaining.next() {
+        let union_set = group.0 | sets[square.to_index()];
+        match find_k_group_recursively(k, sets, remaining, (union_set, group.1 + 1)) {
+            Some(g) => Some(g),
+            None => find_k_group_recursively(k, sets, remaining, group)
+                .map(|(group, indices)| (group, indices | BitBoard::from_square(square))),
+        }
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chess::EMPTY;
+
+    use super::*;
+    use crate::utils::*;
+
+    #[test]
+    fn test_find_k_group() {
+        let mut sets = [!EMPTY; 64];
+        sets[0] = bitboard_of_squares(&[A1, A2]);
+        sets[1] = bitboard_of_squares(&[A3]);
+        sets[2] = bitboard_of_squares(&[A1, A2]);
+        sets[3] = bitboard_of_squares(&[A2]);
+        sets[4] = bitboard_of_squares(&[A1, A3, A4]);
+
+        assert_eq!(find_k_group(1, &sets, BitBoard(1)), None);
+        assert_eq!(
+            find_k_group(1, &sets, BitBoard(63)),
+            Some((sets[1], BitBoard(63 - 2)))
+        );
+        assert_eq!(
+            find_k_group(2, &sets, BitBoard(63)),
+            Some((sets[0] | sets[2], BitBoard(63 - 1 - 4)))
+        );
+        assert_eq!(
+            find_k_group(3, &sets, BitBoard(63)),
+            Some((sets[0] | sets[1] | sets[2], BitBoard(63 - 1 - 2 - 4)))
+        );
+
+        sets[0] = bitboard_of_squares(&[B1, B2, B3]);
+        sets[1] = bitboard_of_squares(&[B2, B3, B4]);
+        sets[2] = bitboard_of_squares(&[B2, B3, B4]);
+        sets[3] = bitboard_of_squares(&[B1, H8]);
+        sets[4] = bitboard_of_squares(&[B1, B2, B4]);
+
+        assert_eq!(
+            find_k_group(4, &sets, BitBoard(63)),
+            Some((
+                sets[0] | sets[1] | sets[2] | sets[4],
+                BitBoard(63 - 1 - 2 - 4 - 16)
+            ))
+        );
+        assert_eq!(
+            find_k_group(5, &sets, BitBoard(31)),
+            Some((sets[0] | sets[1] | sets[2] | sets[3] | sets[4], BitBoard(0)))
+        );
+
+        sets[3] = bitboard_of_squares(&[B1, H8, G8]);
+        assert_eq!(find_k_group(5, &sets, BitBoard(31)), None);
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,8 @@
 mod squares;
 pub use squares::*;
 
+mod k_groups;
+pub use k_groups::*;
+
 mod util;
 pub use util::*;

--- a/src/utils/squares.rs
+++ b/src/utils/squares.rs
@@ -8,6 +8,9 @@ pub const LIGHT_SQUARES: BitBoard = BitBoard(6172840429334713770);
 /// The dark squares of the chess board.
 pub const DARK_SQUARES: BitBoard = BitBoard(12273903644374837845);
 
+/// The light and dark squares of the chess board.
+pub const COLOR_SQUARES: [BitBoard; 2] = [LIGHT_SQUARES, DARK_SQUARES];
+
 /// The A1 square on the chess board.
 pub const A1: Square = Square::A1;
 

--- a/src/utils/util.rs
+++ b/src/utils/util.rs
@@ -8,8 +8,8 @@ use chess::{
 use super::LIGHT_SQUARES;
 
 /// Construct a `BitBoard` out of the given squares.
-#[inline]
-pub fn bitboard_of_squares(squares: &[Square]) -> BitBoard {
+#[cfg(test)]
+pub(crate) fn bitboard_of_squares(squares: &[Square]) -> BitBoard {
     squares
         .iter()
         .fold(EMPTY, |acc, s| acc | BitBoard::from_square(*s))

--- a/src/utils/util.rs
+++ b/src/utils/util.rs
@@ -5,6 +5,8 @@ use chess::{
     BitBoard, Board, Color, Piece, Square, EMPTY,
 };
 
+use super::LIGHT_SQUARES;
+
 /// Construct a `BitBoard` out of the given squares.
 #[inline]
 pub fn bitboard_of_squares(squares: &[Square]) -> BitBoard {
@@ -41,6 +43,14 @@ pub fn rooks(board: &Board, color: Color) -> BitBoard {
 #[inline]
 pub fn queens(board: &Board, color: Color) -> BitBoard {
     board.pieces(Piece::Queen) & board.color_combined(color)
+}
+
+#[inline]
+pub fn square_color(square: Square) -> Color {
+    match BitBoard::from_square(square) & LIGHT_SQUARES {
+        EMPTY => Color::Black,
+        _ => Color::White,
+    }
 }
 
 /// A `BitBoard` with the squares from which a piece of the given `Piece` type


### PR DESCRIPTION
This rule exploits the fact that if there is a group of k pieces with k combined candidate origins, those origins cannot be origins of any other piece.