### PR TITLE
Reachable field in analysis

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -230,6 +230,7 @@ impl Analysis {
 
     /// Update the candidate origins of the piece on the given square, with the
     /// given value.
+    /// Returns a boolean value indicating whether the update changed anything.
     pub(crate) fn update_origins(&mut self, square: Square, value: BitBoard) -> bool {
         if self.origins.value[square.to_index()] == value {
             return false;
@@ -246,8 +247,7 @@ impl Analysis {
 
     /// Update the candidate destinies of the piece that started on the given
     /// square, with the given value.
-    /// Returns a boolean value indicating whether the update actually changed
-    /// the known information on destinies.
+    /// Returns a boolean value indicating whether the update changed anything.
     pub(crate) fn update_destinies(&mut self, square: Square, value: BitBoard) -> bool {
         if self.destinies.value[square.to_index()] == value {
             return false;
@@ -260,6 +260,18 @@ impl Analysis {
         if value == EMPTY {
             self.result = Some(Legality::Illegal);
         }
+        true
+    }
+
+    /// Update the reachable squares of the piece that started on the given
+    /// square, with the given value.
+    /// Returns a boolean value indicating whether the update changed anything.
+    pub(crate) fn update_reachable(&mut self, square: Square, value: BitBoard) -> bool {
+        if self.reachable.value[square.to_index()] == value {
+            return false;
+        }
+        self.reachable.value[square.to_index()] = value;
+        self.reachable.counter += 1;
         true
     }
 

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -280,7 +280,7 @@ impl Analysis {
     /// value.
     #[cfg(test)]
     pub(crate) fn update_captures_lower_bound(&mut self, square: Square, bound: i32) -> bool {
-        if self.captures_bounds.value[square.to_index()].0 == bound {
+        if self.captures_bounds.value[square.to_index()].0 >= bound {
             return false;
         }
         self.captures_bounds.value[square.to_index()].0 = bound;
@@ -292,7 +292,7 @@ impl Analysis {
     /// piece that started the game on the given square, with the given
     /// value.
     pub(crate) fn update_captures_upper_bound(&mut self, square: Square, bound: i32) -> bool {
-        if self.captures_bounds.value[square.to_index()].1 == bound {
+        if self.captures_bounds.value[square.to_index()].1 <= bound {
             return false;
         }
         self.captures_bounds.value[square.to_index()].1 = bound;

--- a/src/legality.rs
+++ b/src/legality.rs
@@ -1,13 +1,6 @@
 use chess::Board;
 
-use crate::{
-    analysis::Analysis,
-    rules::{
-        CapturesBoundsRule, DestiniesRule, MaterialRule, OriginsRule, RefineOriginsRule,
-        RouteFromOriginsRule, RouteToReachable, Rule, SteadyRule,
-    },
-    Legality::Illegal,
-};
+use crate::{analysis::Analysis, rules::*, Legality::Illegal};
 
 /// Initialize all the available rules.
 fn init_rules() -> Vec<Box<dyn Rule>> {
@@ -17,6 +10,7 @@ fn init_rules() -> Vec<Box<dyn Rule>> {
         Box::new(OriginsRule::new()),
         Box::new(RefineOriginsRule::new()),
         Box::new(DestiniesRule::new()),
+        Box::new(SteadyMobilityRule::new()),
         Box::new(CapturesBoundsRule::new()),
         Box::new(RouteFromOriginsRule::new()),
         Box::new(RouteToReachable::new()),

--- a/src/legality.rs
+++ b/src/legality.rs
@@ -4,7 +4,7 @@ use crate::{
     analysis::Analysis,
     rules::{
         CapturesBoundsRule, DestiniesRule, MaterialRule, OriginsRule, RefineOriginsRule,
-        RouteFromOriginsRule, RouteToDestiniesRule, Rule, SteadyRule,
+        RouteFromOriginsRule, RouteToReachable, Rule, SteadyRule,
     },
     Legality::Illegal,
 };
@@ -19,7 +19,7 @@ fn init_rules() -> Vec<Box<dyn Rule>> {
         Box::new(DestiniesRule::new()),
         Box::new(CapturesBoundsRule::new()),
         Box::new(RouteFromOriginsRule::new()),
-        Box::new(RouteToDestiniesRule::new()),
+        Box::new(RouteToReachable::new()),
     ]
 }
 

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -41,8 +41,8 @@ pub use destinies::*;
 mod route_from_origins;
 pub use route_from_origins::*;
 
-mod route_to_destinies;
-pub use route_to_destinies::*;
+mod route_to_reachable;
+pub use route_to_reachable::*;
 
 mod captures_bounds;
 pub use captures_bounds::*;

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -38,6 +38,9 @@ pub use refine_origins::*;
 mod destinies;
 pub use destinies::*;
 
+mod steady_mobility;
+pub use steady_mobility::*;
+
 mod route_from_origins;
 pub use route_from_origins::*;
 

--- a/src/rules/captures_bounds.rs
+++ b/src/rules/captures_bounds.rs
@@ -35,8 +35,6 @@ impl Rule for CapturesBoundsRule {
     fn is_applicable(&self, analysis: &Analysis) -> bool {
         self.captures_bounds_counter != analysis.captures_bounds.counter()
             || self.steady_counter != analysis.steady.counter()
-            || self.captures_bounds_counter == 0
-            || self.steady_counter == 0
     }
 
     fn apply(&self, analysis: &mut Analysis) -> bool {

--- a/src/rules/destinies.rs
+++ b/src/rules/destinies.rs
@@ -10,19 +10,27 @@ use super::{Analysis, Rule};
 #[derive(Debug)]
 pub struct DestiniesRule {
     origins_counter: usize,
+    reachable_counter: usize,
 }
 
 impl Rule for DestiniesRule {
     fn new() -> Self {
-        DestiniesRule { origins_counter: 0 }
+        DestiniesRule {
+            origins_counter: 0,
+            reachable_counter: 0,
+        }
     }
 
     fn update(&mut self, analysis: &Analysis) {
         self.origins_counter = analysis.origins.counter();
+        self.reachable_counter = analysis.reachable.counter();
     }
 
     fn is_applicable(&self, analysis: &Analysis) -> bool {
-        self.origins_counter != analysis.origins.counter() || self.origins_counter == 0
+        self.origins_counter != analysis.origins.counter()
+            || self.reachable_counter != analysis.reachable.counter()
+            || self.origins_counter == 0
+            || self.reachable_counter == 0
     }
 
     fn apply(&self, analysis: &mut Analysis) -> bool {
@@ -33,6 +41,9 @@ impl Rule for DestiniesRule {
                 let origin = analysis.origins(square).to_square();
                 progress |= analysis.update_destinies(origin, BitBoard::from_square(square))
             }
+
+            let reachable_destinies = analysis.destinies(square) & analysis.reachable(square);
+            progress |= analysis.update_destinies(square, reachable_destinies)
         }
         progress
     }

--- a/src/rules/destinies.rs
+++ b/src/rules/destinies.rs
@@ -34,7 +34,7 @@ impl Rule for DestiniesRule {
     fn apply(&self, analysis: &mut Analysis) -> bool {
         let mut progress = false;
 
-        for square in *analysis.board.combined() & !analysis.steady.value {
+        for square in *analysis.board.combined() {
             if analysis.origins(square).popcnt() == 1 {
                 let origin = analysis.origins(square).to_square();
                 progress |= analysis.update_destinies(origin, BitBoard::from_square(square))

--- a/src/rules/destinies.rs
+++ b/src/rules/destinies.rs
@@ -29,8 +29,6 @@ impl Rule for DestiniesRule {
     fn is_applicable(&self, analysis: &Analysis) -> bool {
         self.origins_counter != analysis.origins.counter()
             || self.reachable_counter != analysis.reachable.counter()
-            || self.origins_counter == 0
-            || self.reachable_counter == 0
     }
 
     fn apply(&self, analysis: &mut Analysis) -> bool {

--- a/src/rules/origins.rs
+++ b/src/rules/origins.rs
@@ -5,7 +5,7 @@
 //! Queens, rooks, bishops and knights may also come from their relative 2nd
 //! rank, as they may be promoted.
 
-use chess::{BitBoard, Piece, Square, EMPTY};
+use chess::{BitBoard, Piece, Square};
 
 use super::{Analysis, Rule};
 use crate::utils::square_color;
@@ -15,26 +15,26 @@ use crate::utils::square_color;
 // apply it again.
 #[derive(Debug)]
 pub struct OriginsRule {
-    steady: BitBoard,
+    steady_counter: usize,
 }
 
 impl Rule for OriginsRule {
     fn new() -> Self {
-        OriginsRule { steady: EMPTY }
+        OriginsRule { steady_counter: 0 }
     }
 
     fn update(&mut self, analysis: &Analysis) {
-        self.steady = analysis.steady.value;
+        self.steady_counter = analysis.steady.counter();
     }
 
     fn is_applicable(&self, analysis: &Analysis) -> bool {
-        self.steady != analysis.steady.value || self.steady == EMPTY
+        self.steady_counter != analysis.steady.counter()
     }
 
     fn apply(&self, analysis: &mut Analysis) -> bool {
         let mut progress = false;
 
-        for square in *analysis.board.combined() & analysis.steady.value & !self.steady {
+        for square in analysis.steady.value {
             let square_origins = BitBoard::from_square(square);
             progress |= analysis.update_origins(square, square_origins);
         }

--- a/src/rules/refine_origins.rs
+++ b/src/rules/refine_origins.rs
@@ -24,7 +24,7 @@ impl Rule for RefineOriginsRule {
     }
 
     fn is_applicable(&self, analysis: &Analysis) -> bool {
-        self.origins_counter != analysis.origins.counter() || self.origins_counter == 0
+        self.origins_counter != analysis.origins.counter()
     }
 
     fn apply(&self, analysis: &mut Analysis) -> bool {

--- a/src/rules/route_from_origins.rs
+++ b/src/rules/route_from_origins.rs
@@ -4,8 +4,6 @@
 //! from its candidate origins to its current square. The candidate origins that
 //! do not satisfy this condition are filtered out.
 
-use std::cmp::min;
-
 use chess::{BitBoard, EMPTY};
 
 use super::Rule;
@@ -42,7 +40,6 @@ impl Rule for RouteFromOriginsRule {
             let piece = analysis.piece_type_on(square);
             let color = analysis.piece_color_on(square);
             let mut plausible_origins = EMPTY;
-            let mut min_nb_captures = u32::MAX;
             for origin in analysis.origins(square) {
                 let nb_allowed_captures = analysis.nb_captures_upper_bound(origin);
                 if let Some(n) =
@@ -50,12 +47,10 @@ impl Rule for RouteFromOriginsRule {
                 {
                     if n <= nb_allowed_captures as u32 {
                         plausible_origins |= BitBoard::from_square(origin);
-                        min_nb_captures = min(n, min_nb_captures);
                     }
                 }
             }
             progress |= analysis.update_origins(square, plausible_origins);
-            progress |= analysis.update_captures_upper_bound(square, min_nb_captures as i32);
         }
         progress
     }

--- a/src/rules/route_from_origins.rs
+++ b/src/rules/route_from_origins.rs
@@ -12,21 +12,25 @@ use crate::{analysis::Analysis, utils::distance_from_source};
 #[derive(Debug)]
 pub struct RouteFromOriginsRule {
     mobility_counter: usize,
+    captures_bounds_counter: usize,
 }
 
 impl Rule for RouteFromOriginsRule {
     fn new() -> Self {
         Self {
             mobility_counter: 0,
+            captures_bounds_counter: 0,
         }
     }
 
     fn update(&mut self, analysis: &Analysis) {
         self.mobility_counter = analysis.mobility.counter();
+        self.captures_bounds_counter = analysis.captures_bounds.counter();
     }
 
     fn is_applicable(&self, analysis: &Analysis) -> bool {
-        self.mobility_counter != analysis.mobility.counter() || self.mobility_counter == 0
+        self.mobility_counter != analysis.mobility.counter()
+            || self.captures_bounds_counter != analysis.captures_bounds.counter()
     }
 
     fn apply(&self, analysis: &mut Analysis) -> bool {

--- a/src/rules/route_from_origins.rs
+++ b/src/rules/route_from_origins.rs
@@ -4,6 +4,8 @@
 //! from its candidate origins to its current square. The candidate origins that
 //! do not satisfy this condition are filtered out.
 
+use std::cmp::min;
+
 use chess::{BitBoard, EMPTY};
 
 use super::Rule;
@@ -40,6 +42,7 @@ impl Rule for RouteFromOriginsRule {
             let piece = analysis.piece_type_on(square);
             let color = analysis.piece_color_on(square);
             let mut plausible_origins = EMPTY;
+            let mut min_nb_captures = u32::MAX;
             for origin in analysis.origins(square) {
                 let nb_allowed_captures = analysis.nb_captures_upper_bound(origin);
                 if let Some(n) =
@@ -47,10 +50,12 @@ impl Rule for RouteFromOriginsRule {
                 {
                     if n <= nb_allowed_captures as u32 {
                         plausible_origins |= BitBoard::from_square(origin);
+                        min_nb_captures = min(n, min_nb_captures);
                     }
                 }
             }
             progress |= analysis.update_origins(square, plausible_origins);
+            progress |= analysis.update_captures_upper_bound(square, min_nb_captures as i32);
         }
         progress
     }

--- a/src/rules/route_to_reachable.rs
+++ b/src/rules/route_to_reachable.rs
@@ -1,8 +1,7 @@
-//! Route to destinies rule.
+//! Route to reachable rule.
 //!
-//! This rule makes sure that for every piece in the starting array, there
-//! exists a path from its original square to its candidate destinies.
-//! Unreachable destinies are filtered out.
+//! This rule filters the set of reachable squares of every piece by removing
+//! the squares for which there does not exists a path from its original square.
 
 use chess::{BitBoard, Board, ALL_COLORS, EMPTY};
 
@@ -10,11 +9,11 @@ use super::{Rule, COLOR_ORIGINS};
 use crate::{analysis::Analysis, utils::distance_to_target};
 
 #[derive(Debug)]
-pub struct RouteToDestiniesRule {
+pub struct RouteToReachable {
     mobility_counter: usize,
 }
 
-impl Rule for RouteToDestiniesRule {
+impl Rule for RouteToReachable {
     fn new() -> Self {
         Self {
             mobility_counter: 0,
@@ -36,17 +35,17 @@ impl Rule for RouteToDestiniesRule {
             for square in COLOR_ORIGINS[color.to_index()] & !analysis.steady.value {
                 let piece = Board::default().piece_on(square).unwrap();
                 let nb_allowed_captures = analysis.nb_captures_upper_bound(square);
-                let mut reachable_destinies = EMPTY;
-                for destiny in analysis.destinies(square) {
+                let mut reachable_targets = EMPTY;
+                for target in analysis.reachable(square) {
                     if let Some(n) =
-                        distance_to_target(&analysis.mobility.value, square, destiny, piece, color)
+                        distance_to_target(&analysis.mobility.value, square, target, piece, color)
                     {
                         if n <= nb_allowed_captures as u32 {
-                            reachable_destinies |= BitBoard::from_square(destiny);
+                            reachable_targets |= BitBoard::from_square(target);
                         }
                     }
                 }
-                progress |= analysis.update_destinies(square, reachable_destinies);
+                progress |= analysis.update_reachable(square, reachable_targets);
             }
         }
         progress

--- a/src/rules/route_to_reachable.rs
+++ b/src/rules/route_to_reachable.rs
@@ -11,21 +11,25 @@ use crate::{analysis::Analysis, utils::distance_to_target};
 #[derive(Debug)]
 pub struct RouteToReachable {
     mobility_counter: usize,
+    captures_bounds_counter: usize,
 }
 
 impl Rule for RouteToReachable {
     fn new() -> Self {
         Self {
             mobility_counter: 0,
+            captures_bounds_counter: 0,
         }
     }
 
     fn update(&mut self, analysis: &Analysis) {
         self.mobility_counter = analysis.mobility.counter();
+        self.captures_bounds_counter = analysis.captures_bounds.counter();
     }
 
     fn is_applicable(&self, analysis: &Analysis) -> bool {
-        self.mobility_counter != analysis.mobility.counter() || self.mobility_counter == 0
+        self.mobility_counter != analysis.mobility.counter()
+            || self.captures_bounds_counter != analysis.captures_bounds.counter()
     }
 
     fn apply(&self, analysis: &mut Analysis) -> bool {

--- a/src/rules/route_to_reachable.rs
+++ b/src/rules/route_to_reachable.rs
@@ -36,7 +36,7 @@ impl Rule for RouteToReachable {
         let mut progress = false;
 
         for color in ALL_COLORS {
-            for square in COLOR_ORIGINS[color.to_index()] & !analysis.steady.value {
+            for square in COLOR_ORIGINS[color.to_index()] {
                 let piece = Board::default().piece_on(square).unwrap();
                 let nb_allowed_captures = analysis.nb_captures_upper_bound(square);
                 let mut reachable_targets = EMPTY;

--- a/src/rules/steady.rs
+++ b/src/rules/steady.rs
@@ -27,7 +27,7 @@ impl Rule for SteadyRule {
     }
 
     fn is_applicable(&self, analysis: &Analysis) -> bool {
-        self.steady_counter != analysis.steady.counter() || self.steady_counter == 0
+        self.steady_counter != analysis.steady.counter()
     }
 
     fn apply(&self, analysis: &mut Analysis) -> bool {

--- a/src/rules/steady_mobility.rs
+++ b/src/rules/steady_mobility.rs
@@ -1,0 +1,90 @@
+//! Steady mobility rule.
+//!
+//! We refine the mobility graphs based on the information on steady pieces:
+//!  - No piece may have passed through a steady-piece square.
+//!  - No piece may have moved from a square that was checking a steady king.
+
+use chess::{ALL_COLORS, ALL_PIECES};
+
+use super::{Analysis, Rule};
+
+#[derive(Debug)]
+pub struct SteadyMobilityRule {
+    steady_counter: usize,
+}
+
+impl Rule for SteadyMobilityRule {
+    fn new() -> Self {
+        SteadyMobilityRule { steady_counter: 0 }
+    }
+
+    fn update(&mut self, analysis: &Analysis) {
+        self.steady_counter = analysis.steady.counter();
+    }
+
+    fn is_applicable(&self, analysis: &Analysis) -> bool {
+        self.steady_counter != analysis.steady.counter()
+    }
+
+    fn apply(&self, analysis: &mut Analysis) -> bool {
+        let mut progress = false;
+
+        // Remove all arrows that pass through a steady piece
+        for square in analysis.steady.value {
+            for color in ALL_COLORS {
+                for piece in ALL_PIECES {
+                    progress |= analysis.remove_incoming_edges(piece, color, square);
+                    progress |= analysis.remove_outgoing_edges(piece, color, square);
+                    progress |= analysis.remove_edges_passing_through_square(piece, color, square);
+                }
+            }
+        }
+
+        progress
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use chess::{get_rank, Board, Color::*, Piece::*, Rank};
+
+    use super::*;
+    use crate::{rules::Rule, utils::*};
+
+    #[test]
+    fn test_steady_mobility_rule() {
+        let board = Board::from_str("1k6/8/8/8/8/8/8/K7 w - -").expect("Valid Position");
+        let mut analysis = Analysis::new(&board);
+        let steady_mobility = SteadyMobilityRule::new();
+
+        steady_mobility.apply(&mut analysis);
+
+        // any square should be reachable from H1 for a white rook
+        assert_eq!(
+            distance_to_target(&analysis.mobility.value, H1, H8, Rook, White),
+            Some(0)
+        );
+
+        // learn that H7 is steady
+        analysis.update_steady(bitboard_of_squares(&[H7]));
+        steady_mobility.apply(&mut analysis);
+
+        // H8 should still be reachable, not directly, but reachable
+        assert_eq!(
+            distance_to_target(&analysis.mobility.value, H1, H8, Rook, White),
+            Some(0)
+        );
+
+        // not learn that the whole 7th rank is steady
+        analysis.update_steady(get_rank(Rank::Seventh));
+        steady_mobility.apply(&mut analysis);
+
+        // H8 should no longer be reachable
+        assert_eq!(
+            distance_to_target(&analysis.mobility.value, H1, H8, Rook, White),
+            None
+        );
+    }
+}

--- a/src/utils/chess_utils.rs
+++ b/src/utils/chess_utils.rs
@@ -1,8 +1,8 @@
 //! Util functions.
 
 use chess::{
-    get_bishop_rays, get_king_moves, get_knight_moves, get_pawn_attacks, get_pawn_quiets, get_rank,
-    get_rook_rays, BitBoard, Board, Color, Piece, Square, EMPTY,
+    get_bishop_rays, get_file, get_king_moves, get_knight_moves, get_pawn_attacks, get_pawn_quiets,
+    get_rank, get_rook_rays, BitBoard, Board, Color, Piece, Square, EMPTY,
 };
 
 use super::LIGHT_SQUARES;
@@ -79,6 +79,19 @@ pub fn predecessors(piece: Piece, color: Color, square: Square) -> BitBoard {
         predecessors &= !get_rank(color.to_my_backrank());
     }
     predecessors & (get_king_moves(square) | get_knight_moves(square))
+}
+
+/// A `BitBoard` with the squares from which a piece of the given `Piece` type
+/// and `Color` will always check an opponent king on the given `Square`, independently
+/// of the configuration of other pieces.
+#[inline]
+pub fn checking_predecessors(piece: Piece, color: Color, square: Square) -> BitBoard {
+    let mut predecessors = predecessors(piece, color, square);
+    // Remove quiet pawn moves
+    if piece == Piece::Pawn {
+        predecessors &= !get_file(square.get_file());
+    }
+    predecessors
 }
 
 #[cfg(test)]

--- a/src/utils/mobility.rs
+++ b/src/utils/mobility.rs
@@ -61,8 +61,7 @@ impl MobilityGraph {
 
     /// Makes sure the edge between the given squares disappears from the graph.
     /// Returns `true` iff this operation modifies the graph.
-    #[allow(dead_code)]
-    fn remove_edge(&mut self, source: Square, target: Square) -> bool {
+    pub fn remove_edge(&mut self, source: Square, target: Square) -> bool {
         match self.edge(source, target) {
             None => false,
             Some(edge) => {
@@ -81,8 +80,7 @@ impl MobilityGraph {
 
     /// Makes sure the graph does not have outgoing edges from the given node.
     /// Returns `true` iff this operation modifies the graph.
-    #[allow(dead_code)]
-    fn remove_outgoing_edges(&mut self, source: Square) -> bool {
+    pub fn remove_outgoing_edges(&mut self, source: Square) -> bool {
         let outgoing_edges: Vec<_> = self
             .graph
             .edges_directed(self.node(source), Outgoing)
@@ -94,8 +92,7 @@ impl MobilityGraph {
 
     /// Makes sure the graph does not have incoming edges to the given node.
     /// Returns `true` iff this operation modifies the graph.
-    #[allow(dead_code)]
-    fn remove_incoming_edges(&mut self, target: Square) -> bool {
+    pub fn remove_incoming_edges(&mut self, target: Square) -> bool {
         let incoming_edges: Vec<_> = self
             .graph
             .edges_directed(self.node(target), Incoming)
@@ -103,6 +100,12 @@ impl MobilityGraph {
             .collect();
         self.remove_edges(&incoming_edges);
         !incoming_edges.is_empty()
+    }
+
+    /// Makes sure the given node is disconnected from the rest of the graph.
+    /// Returns `true` iff this operation modifies the graph.
+    pub fn remove_node_edges(&mut self, node: Square) -> bool {
+        self.remove_outgoing_edges(node) || self.remove_incoming_edges(node)
     }
 
     pub fn distance(&self, source: Square, target: Square) -> Option<u32> {

--- a/src/utils/mobility.rs
+++ b/src/utils/mobility.rs
@@ -104,12 +104,14 @@ impl MobilityGraph {
 
     /// Makes sure the given node is disconnected from the rest of the graph.
     /// Returns `true` iff this operation modifies the graph.
+    #[allow(dead_code)]
     pub fn remove_node_edges(&mut self, node: Square) -> bool {
         self.remove_outgoing_edges(node) || self.remove_incoming_edges(node)
     }
 
     pub fn distance(&self, source: Square, target: Square) -> Option<u32> {
         let node_map = dijkstra(&self.graph, self.node(source), None, |e| *e.weight());
+        println!("{} -> {}\n{:?}", source, target, node_map);
         node_map.get(&self.node(target)).copied()
     }
 }


### PR DESCRIPTION
Introduce a new field to keep track of all the reachable squares by every piece.

Add a simple mobility rule that removes from the mobility graphs all the arrows that go from/into or pass through steady pieces.