### PR TITLE
Pawn on 3rd rank rule

### DIFF
--- a/src/legality.rs
+++ b/src/legality.rs
@@ -11,6 +11,7 @@ fn init_rules() -> Vec<Box<dyn Rule>> {
         Box::new(RefineOriginsRule::new()),
         Box::new(DestiniesRule::new()),
         Box::new(SteadyMobilityRule::new()),
+        Box::new(PawnOn3rdRankRule::new()),
         Box::new(CapturesBoundsRule::new()),
         Box::new(RouteFromOriginsRule::new()),
         Box::new(RouteToReachable::new()),

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -41,6 +41,9 @@ pub use destinies::*;
 mod steady_mobility;
 pub use steady_mobility::*;
 
+mod pawn_on_3rd_rank;
+pub use pawn_on_3rd_rank::*;
+
 mod route_from_origins;
 pub use route_from_origins::*;
 

--- a/src/rules/captures_bounds.rs
+++ b/src/rules/captures_bounds.rs
@@ -77,7 +77,7 @@ mod tests {
     use chess::{Board, Square};
 
     use super::*;
-    use crate::{analysis::Analysis, rules::Rule, utils::*};
+    use crate::{analysis::Analysis, utils::*};
 
     #[test]
     fn test_captures_bounds_rule() {

--- a/src/rules/destinies.rs
+++ b/src/rules/destinies.rs
@@ -5,7 +5,7 @@
 
 use chess::BitBoard;
 
-use super::{Analysis, Rule};
+use super::{Analysis, Rule, ALL_ORIGINS};
 
 #[derive(Debug)]
 pub struct DestiniesRule {
@@ -34,7 +34,7 @@ impl Rule for DestiniesRule {
     fn apply(&self, analysis: &mut Analysis) -> bool {
         let mut progress = false;
 
-        for square in *analysis.board.combined() {
+        for square in ALL_ORIGINS {
             if analysis.origins(square).popcnt() == 1 {
                 let origin = analysis.origins(square).to_square();
                 progress |= analysis.update_destinies(origin, BitBoard::from_square(square))

--- a/src/rules/destinies.rs
+++ b/src/rules/destinies.rs
@@ -1,9 +1,6 @@
 //! Destinies rule.
 //!
-//! If the piece currently on `s` has only one candidate origin `o`, then the
-//! destiny of `o` must be `s`.
-
-use chess::BitBoard;
+//! We filter out destinies that are not reachable.
 
 use super::{Analysis, Rule, ALL_ORIGINS};
 
@@ -35,47 +32,9 @@ impl Rule for DestiniesRule {
         let mut progress = false;
 
         for square in ALL_ORIGINS {
-            if analysis.origins(square).popcnt() == 1 {
-                let origin = analysis.origins(square).to_square();
-                progress |= analysis.update_destinies(origin, BitBoard::from_square(square))
-            }
-
             let reachable_destinies = analysis.destinies(square) & analysis.reachable(square);
             progress |= analysis.update_destinies(square, reachable_destinies)
         }
         progress
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::str::FromStr;
-
-    use chess::{Board, EMPTY};
-
-    use super::*;
-    use crate::{rules::Rule, utils::*};
-
-    #[test]
-    fn test_destinies_rule() {
-        let board = Board::from_str("1k6/8/8/8/8/8/8/K7 w - -").expect("Valid Position");
-        let mut analysis = Analysis::new(&board);
-        let destinies_rule = DestiniesRule::new();
-
-        destinies_rule.apply(&mut analysis);
-
-        // we should not have any information on destinies yet
-        assert_eq!(analysis.destinies(E1), !EMPTY);
-        assert_eq!(analysis.destinies(E7), !EMPTY);
-
-        // learn that E1 is the only candidate origin of the piece on A1
-        analysis.update_origins(A1, bitboard_of_squares(&[E1]));
-        destinies_rule.apply(&mut analysis);
-
-        // the destinies of E1 must have been updated to A1
-        assert_eq!(analysis.destinies(E1), bitboard_of_squares(&[A1]));
-
-        // others are still uncertain
-        assert_eq!(analysis.destinies(E7), !EMPTY);
     }
 }

--- a/src/rules/origins.rs
+++ b/src/rules/origins.rs
@@ -64,6 +64,7 @@ fn origins_of_piece_on(piece: Piece, square: Square) -> BitBoard {
     }
 }
 
+pub const ALL_ORIGINS: BitBoard = BitBoard(18446462598732906495); // 1st, 2nd, 7th & 8th ranks
 pub const COLOR_ORIGINS: [BitBoard; 2] = [
     BitBoard(65535),                // 1st & 2nd ranks
     BitBoard(18446462598732840960), // 7th & 8th ranks

--- a/src/rules/pawn_on_3rd_rank.rs
+++ b/src/rules/pawn_on_3rd_rank.rs
@@ -1,0 +1,102 @@
+//! Pawn on 3rd rank rule.
+//!
+//! If there is a pawn on their relative 3rd rank with a single candidate
+//! origin, no other piece can possibly have moved between such origin and its
+//! current square. We remove all such moves from the mobility graphs
+//! accordingly.
+
+use chess::{get_rank, Color, Piece, Rank, ALL_COLORS, ALL_PIECES};
+
+use super::{Analysis, Rule};
+
+#[derive(Debug)]
+pub struct PawnOn3rdRankRule {
+    origins_counter: usize,
+}
+
+impl Rule for PawnOn3rdRankRule {
+    fn new() -> Self {
+        PawnOn3rdRankRule { origins_counter: 0 }
+    }
+
+    fn update(&mut self, analysis: &Analysis) {
+        self.origins_counter = analysis.origins.counter();
+    }
+
+    fn is_applicable(&self, analysis: &Analysis) -> bool {
+        self.origins_counter != analysis.origins.counter()
+    }
+
+    fn apply(&self, analysis: &mut Analysis) -> bool {
+        let mut progress = false;
+
+        for color in ALL_COLORS {
+            let third_rank = match color {
+                Color::White => Rank::Third,
+                Color::Black => Rank::Sixth,
+            };
+            for square in analysis.board.color_combined(color)
+                & analysis.board.pieces(Piece::Pawn)
+                & get_rank(third_rank)
+            {
+                // if the 3rd rank pawn has a single candidate origin
+                if analysis.origins(square).popcnt() == 1 {
+                    let origin = analysis.origins(square).to_square();
+
+                    // remove all arrows that pass through that origin and its current square
+                    for other_color in ALL_COLORS {
+                        for piece in ALL_PIECES {
+                            if piece != Piece::Pawn || other_color != color {
+                                progress |= analysis.remove_edges_passing_through_squares(
+                                    piece,
+                                    other_color,
+                                    origin,
+                                    square,
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        progress
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::str::FromStr;
+
+    use chess::{BitBoard, Board, Color::*, Piece::*};
+
+    use super::*;
+    use crate::utils::*;
+
+    #[test]
+    fn test_pawn_on_3rd_rank() {
+        let board = Board::from_str("rnbqkbnr/pppppppp/8/8/8/2P5/P1PPPPPP/RNBQKBNR w KQkq -")
+            .expect("Valid Position");
+        let mut analysis = Analysis::new(&board);
+
+        let pawn_on_3rd_rank = PawnOn3rdRankRule::new();
+        pawn_on_3rd_rank.apply(&mut analysis);
+
+        // the connection between A1 and H8 should be enabled for white bishops
+        assert!(analysis.mobility.value[White.to_index()][Bishop.to_index()].exists_edge(A1, H8));
+
+        // learn that B2 is the only origin of the pawn on C3
+        analysis.update_origins(C3, BitBoard::from_square(B2));
+        pawn_on_3rd_rank.apply(&mut analysis);
+
+        // the connections between B2 and C3 should now be disabled
+        assert!(!analysis.mobility.value[White.to_index()][Bishop.to_index()].exists_edge(A1, H8));
+        assert!(!analysis.mobility.value[White.to_index()][Bishop.to_index()].exists_edge(B2, C3));
+        assert!(!analysis.mobility.value[White.to_index()][Bishop.to_index()].exists_edge(B2, C4));
+        assert!(!analysis.mobility.value[White.to_index()][Bishop.to_index()].exists_edge(A1, C3));
+
+        // but for a white pawn the connection B2 -> C3 should still be enabled
+        assert!(analysis.mobility.value[White.to_index()][Pawn.to_index()].exists_edge(B2, C3));
+    }
+}

--- a/src/rules/route_from_origins.rs
+++ b/src/rules/route_from_origins.rs
@@ -13,6 +13,7 @@ use crate::{analysis::Analysis, utils::distance_from_origin};
 pub struct RouteFromOriginsRule {
     mobility_counter: usize,
     captures_bounds_counter: usize,
+    steady_counter: usize,
 }
 
 impl Rule for RouteFromOriginsRule {
@@ -20,17 +21,20 @@ impl Rule for RouteFromOriginsRule {
         Self {
             mobility_counter: 0,
             captures_bounds_counter: 0,
+            steady_counter: 0,
         }
     }
 
     fn update(&mut self, analysis: &Analysis) {
         self.mobility_counter = analysis.mobility.counter();
         self.captures_bounds_counter = analysis.captures_bounds.counter();
+        self.steady_counter = analysis.steady.counter();
     }
 
     fn is_applicable(&self, analysis: &Analysis) -> bool {
         self.mobility_counter != analysis.mobility.counter()
             || self.captures_bounds_counter != analysis.captures_bounds.counter()
+            || self.steady_counter != analysis.steady.counter()
     }
 
     fn apply(&self, analysis: &mut Analysis) -> bool {

--- a/src/rules/route_from_origins.rs
+++ b/src/rules/route_from_origins.rs
@@ -7,7 +7,7 @@
 use chess::{BitBoard, EMPTY};
 
 use super::Rule;
-use crate::{analysis::Analysis, utils::distance_from_source};
+use crate::{analysis::Analysis, utils::distance_from_origin};
 
 #[derive(Debug)]
 pub struct RouteFromOriginsRule {
@@ -43,7 +43,7 @@ impl Rule for RouteFromOriginsRule {
             for origin in analysis.origins(square) {
                 let nb_allowed_captures = analysis.nb_captures_upper_bound(origin);
                 if let Some(n) =
-                    distance_from_source(&analysis.mobility.value, origin, square, piece, color)
+                    distance_from_origin(&analysis.mobility.value, origin, square, piece, color)
                 {
                     if n <= nb_allowed_captures as u32 {
                         plausible_origins |= BitBoard::from_square(origin);

--- a/src/rules/route_to_reachable.rs
+++ b/src/rules/route_to_reachable.rs
@@ -3,7 +3,7 @@
 //! This rule filters the set of reachable squares of every piece by removing
 //! the squares for which there does not exists a path from its original square.
 
-use chess::{BitBoard, Board, ALL_COLORS, EMPTY};
+use chess::{BitBoard, Board, ALL_COLORS};
 
 use super::{Rule, COLOR_ORIGINS};
 use crate::{analysis::Analysis, utils::distance_to_target};
@@ -12,6 +12,7 @@ use crate::{analysis::Analysis, utils::distance_to_target};
 pub struct RouteToReachable {
     mobility_counter: usize,
     captures_bounds_counter: usize,
+    steady_counter: usize,
 }
 
 impl Rule for RouteToReachable {
@@ -19,17 +20,20 @@ impl Rule for RouteToReachable {
         Self {
             mobility_counter: 0,
             captures_bounds_counter: 0,
+            steady_counter: 0,
         }
     }
 
     fn update(&mut self, analysis: &Analysis) {
         self.mobility_counter = analysis.mobility.counter();
         self.captures_bounds_counter = analysis.captures_bounds.counter();
+        self.steady_counter = analysis.steady.counter();
     }
 
     fn is_applicable(&self, analysis: &Analysis) -> bool {
         self.mobility_counter != analysis.mobility.counter()
             || self.captures_bounds_counter != analysis.captures_bounds.counter()
+            || self.steady_counter != analysis.steady.counter()
     }
 
     fn apply(&self, analysis: &mut Analysis) -> bool {
@@ -39,8 +43,8 @@ impl Rule for RouteToReachable {
             for square in COLOR_ORIGINS[color.to_index()] {
                 let piece = Board::default().piece_on(square).unwrap();
                 let nb_allowed_captures = analysis.nb_captures_upper_bound(square);
-                let mut reachable_targets = EMPTY;
-                for target in analysis.reachable(square) {
+                let mut reachable_targets = BitBoard::from_square(square);
+                for target in analysis.reachable(square) & !analysis.steady.value {
                     if let Some(n) =
                         distance_to_target(&analysis.mobility.value, square, target, piece, color)
                     {

--- a/src/rules/steady_mobility.rs
+++ b/src/rules/steady_mobility.rs
@@ -6,9 +6,8 @@
 
 use chess::{ALL_COLORS, ALL_PIECES};
 
-use crate::utils::checking_predecessors;
-
 use super::{Analysis, Rule};
+use crate::utils::checking_predecessors;
 
 #[derive(Debug)]
 pub struct SteadyMobilityRule {

--- a/src/rules/steady_mobility.rs
+++ b/src/rules/steady_mobility.rs
@@ -64,7 +64,7 @@ mod tests {
     use chess::{get_rank, Board, Color::*, Piece::*, Rank};
 
     use super::*;
-    use crate::{rules::Rule, utils::*};
+    use crate::utils::*;
 
     #[test]
     fn test_steady_pieces() {

--- a/src/utils/chess_utils.rs
+++ b/src/utils/chess_utils.rs
@@ -82,8 +82,8 @@ pub fn predecessors(piece: Piece, color: Color, square: Square) -> BitBoard {
 }
 
 /// A `BitBoard` with the squares from which a piece of the given `Piece` type
-/// and `Color` will always check an opponent king on the given `Square`, independently
-/// of the configuration of other pieces.
+/// and `Color` will always check an opponent king on the given `Square`,
+/// independently of the configuration of other pieces.
 #[inline]
 pub fn checking_predecessors(piece: Piece, color: Color, square: Square) -> BitBoard {
     let mut predecessors = predecessors(piece, color, square);

--- a/src/utils/mobility.rs
+++ b/src/utils/mobility.rs
@@ -111,37 +111,39 @@ impl MobilityGraph {
 
     pub fn distance(&self, source: Square, target: Square) -> Option<u32> {
         let node_map = dijkstra(&self.graph, self.node(source), None, |e| *e.weight());
-        println!("{} -> {}\n{:?}", source, target, node_map);
         node_map.get(&self.node(target)).copied()
     }
 }
 
 /// The minimum number of captures necessary for the given piece of the
-/// given color to go from `source` to `target`, according to the
-/// current information about the position. If this function returns
-/// `None`, the route from `source` to `target` is definitely
+/// given color to go from the starting square `origin` to `target`, according
+/// to the current information about the position. If this function returns
+/// `None`, the route from `origin` to `target` is definitely
 /// impossible. If this function returns `Some(n)`, at least `n`
 /// captures are required (but this does not mean that it is possible
 /// with exactly `n` captures).
 ///
-/// Note that we also consider the possibility of the piece starting its
-/// journey as a pawn, and having promoted.
-pub fn distance_from_source(
+/// Note that if the origin square is in the (relative) 2nd rank, the pawn may
+/// have to promote before becoming the desired piece.
+pub fn distance_from_origin(
     mobility_graphs: &[[MobilityGraph; NUM_PIECES]; NUM_COLORS],
-    source: Square,
+    origin: Square,
     target: Square,
     piece: Piece,
     color: Color,
 ) -> Option<u32> {
     let piece_graph = &mobility_graphs[color.to_index()][piece.to_index()];
-    // the distance without promotions
-    let mut distance = piece_graph.distance(source, target);
-
-    // consider the possibility of a promotion
-    if piece != Piece::Pawn && piece != Piece::King {
+    if (BitBoard::from_square(origin) & get_rank(color.to_second_rank())) == EMPTY
+        || piece == Piece::Pawn
+    {
+        // the distance without promotions
+        piece_graph.distance(origin, target)
+    } else {
+        // the distance after promoting
         let pawn_graph = &mobility_graphs[color.to_index()][Piece::Pawn.to_index()];
+        let mut distance = None;
         for promoting_square in get_rank(color.to_their_backrank()) {
-            let d1 = pawn_graph.distance(source, promoting_square);
+            let d1 = pawn_graph.distance(origin, promoting_square);
             let d2 = piece_graph.distance(promoting_square, target);
             if d1.is_some()
                 && d2.is_some()
@@ -150,8 +152,8 @@ pub fn distance_from_source(
                 distance = Some(d1.unwrap() + d2.unwrap());
             }
         }
+        distance
     }
-    distance
 }
 
 /// The minimum number of captures necessary for the given piece of the
@@ -229,18 +231,18 @@ mod tests {
     }
 
     #[test]
-    fn test_distance_from_source() {
+    fn test_distance_from_origin() {
         let mut graphs = [
             core::array::from_fn(|i| MobilityGraph::init(ALL_PIECES[i], Color::White)),
             core::array::from_fn(|i| MobilityGraph::init(ALL_PIECES[i], Color::Black)),
         ];
 
         // a bishop on H5 cannot have come from C1, a dark square
-        assert_eq!(distance_from_source(&graphs, C1, H5, Bishop, White), None);
+        assert_eq!(distance_from_origin(&graphs, C1, H5, Bishop, White), None);
 
-        // but it may have come from B1, a light square, no captures needed
+        // but it may have come from F1, a light square, no captures needed
         assert_eq!(
-            distance_from_source(&graphs, B1, H5, Bishop, White),
+            distance_from_origin(&graphs, B1, H5, Bishop, White),
             Some(0)
         );
 
@@ -248,47 +250,42 @@ mod tests {
         // it could have been a promoted pawn, at least a capture is needed though,
         // to switch to a file with a light promoting square
         assert_eq!(
-            distance_from_source(&graphs, B2, H5, Bishop, White),
+            distance_from_origin(&graphs, B2, H5, Bishop, White),
             Some(1)
         );
 
-        // from E3, no captures are needed
+        // or from B7 if the bishop were Black (as B1 is light)
         assert_eq!(
-            distance_from_source(&graphs, E3, H5, Bishop, White),
-            Some(0)
-        );
-
-        // or from B2 if the bishop were Black (as B1 is light)
-        assert_eq!(
-            distance_from_source(&graphs, B2, H5, Bishop, Black),
+            distance_from_origin(&graphs, B7, H5, Bishop, Black),
             Some(0)
         );
 
         // let us remove some graph connections
-        graphs[White.to_index()][Bishop.to_index()].remove_outgoing_edges(E8);
+        graphs[White.to_index()][Bishop.to_index()].remove_outgoing_edges(A8);
+        graphs[White.to_index()][Bishop.to_index()].remove_outgoing_edges(C8);
 
-        // now we cannot promote on E8 because we disconnected E8 from H5
+        // now we cannot promote on A8 or C8, it has to be E8 which takes 3 captures
         assert_eq!(
-            distance_from_source(&graphs, E3, H5, Bishop, White),
-            Some(2)
+            distance_from_origin(&graphs, B2, H5, Bishop, White),
+            Some(3)
         );
 
         // a black pawn on C3 can come from F7, but it takes 3 captures
-        assert_eq!(distance_from_source(&graphs, F7, C3, Pawn, Black), Some(3));
+        assert_eq!(distance_from_origin(&graphs, F7, C3, Pawn, Black), Some(3));
 
         // of course, it cannot come from G8
-        assert_eq!(distance_from_source(&graphs, G8, C3, Pawn, Black), None);
+        assert_eq!(distance_from_origin(&graphs, G8, C3, Pawn, Black), None);
 
         // and it cannot come from H7, because it would not be a pawn after a promotion
-        assert_eq!(distance_from_source(&graphs, H7, C3, Pawn, Black), None);
+        assert_eq!(distance_from_origin(&graphs, H7, C3, Pawn, Black), None);
 
         // if we remove the connection E6 -> D5, it can still come from F7
         graphs[Black.to_index()][Pawn.to_index()].remove_edge(E6, D5);
-        assert_eq!(distance_from_source(&graphs, F7, C3, Pawn, Black), Some(3));
+        assert_eq!(distance_from_origin(&graphs, F7, C3, Pawn, Black), Some(3));
 
         // but also removing E5 -> D4 will disconnect it from F7
         graphs[Black.to_index()][Pawn.to_index()].remove_edge(E5, D4);
-        assert_eq!(distance_from_source(&graphs, F7, C3, Pawn, Black), None);
+        assert_eq!(distance_from_origin(&graphs, F7, C3, Pawn, Black), None);
     }
 
     #[test]

--- a/src/utils/mobility.rs
+++ b/src/utils/mobility.rs
@@ -59,6 +59,12 @@ impl MobilityGraph {
             .add_edge(self.node(source), self.node(target), weight);
     }
 
+    #[cfg(test)]
+    /// Tells whether there exists an edge between the two given squares.
+    pub fn exists_edge(&self, source: Square, target: Square) -> bool {
+        self.edge(source, target).is_some()
+    }
+
     /// Makes sure the edge between the given squares disappears from the graph.
     /// Returns `true` iff this operation modifies the graph.
     pub fn remove_edge(&mut self, source: Square, target: Square) -> bool {


### PR DESCRIPTION
- Introduce the 3rd rank pawn rule.
- Improve destinies rule (replace unique-origin logic by a more general k_group logic).