### PR TITLE
Tombs rule

### DIFF
--- a/src/legality.rs
+++ b/src/legality.rs
@@ -17,6 +17,7 @@ fn init_rules() -> Vec<Box<dyn Rule>> {
         Box::new(RouteFromOriginsRule::new()),
         Box::new(RouteToReachable::new()),
         Box::new(MissingRule::new()),
+        Box::new(CapturesRule::new()),
         Box::new(TombsRule::new()),
     ]
 }
@@ -39,6 +40,7 @@ pub fn analyze(board: &Board) -> Analysis {
         let mut progress = false;
         for rule in rules.iter_mut() {
             if rule.is_applicable(&analysis) && analysis.result.is_none() {
+                println!("{:?}", rule);
                 rule.update(&analysis);
                 progress |= rule.apply(&mut analysis);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,14 @@
 use std::str::FromStr;
 
 use chess::Board;
-use sherlock::is_legal;
+use sherlock::analyze;
 
 fn main() {
-    let board = Board::from_str("rnbqkbnr/ppppppp1/8/8/8/8/1PPPPP1P/RNBQKBNR w Kkq -")
+    // let board = Board::from_str("r1b1kb1r/pp1ppppp/2p5/8/8/2Q5/PP1PPPPP/RN1QKBNR
+    // w KQkq -")
+    let board = Board::from_str("r2qkb1r/ppp1pppp/8/7n/b2P4/8/PPPPP1PP/RNBQKBNR b KQkq -")
+        // let board = Board::from_str("r1bqkb1r/1ppppppp/8/2P5/8/8/PPPPP1PP/R1BQKB1R w KQkq -")
         .expect("Valid Position");
-    println!("is_legal: {}", is_legal(&board))
+    let analysis = analyze(&board);
+    println!("{}", analysis)
 }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -61,3 +61,6 @@ pub use missing::*;
 
 mod captures;
 pub use captures::*;
+
+mod tombs;
+pub use tombs::*;

--- a/src/rules/tombs.rs
+++ b/src/rules/tombs.rs
@@ -1,0 +1,131 @@
+//! Tombs rule.
+//!
+//! We make sure that all known capturing squares can be reached by an opponent
+//! piece to be captured. This allows us to deduce new information about e.g.
+//! the destinies of a pieces.
+
+use chess::{BitBoard, Color, Square, ALL_COLORS, EMPTY};
+
+use super::{Analysis, Rule, COLOR_ORIGINS};
+use crate::{utils::find_k_group, Legality};
+
+#[derive(Debug)]
+pub struct TombsRule {
+    destinies_counter: usize,
+    missing_counter: usize,
+    captures_counter: usize,
+}
+
+impl Rule for TombsRule {
+    fn new() -> Self {
+        TombsRule {
+            destinies_counter: 0,
+            missing_counter: 0,
+            captures_counter: 0,
+        }
+    }
+
+    fn update(&mut self, analysis: &Analysis) {
+        self.destinies_counter = analysis.destinies.counter();
+        self.missing_counter = analysis.missing.counter();
+        self.captures_counter = analysis.captures.counter();
+    }
+
+    fn is_applicable(&self, analysis: &Analysis) -> bool {
+        self.destinies_counter != analysis.destinies.counter()
+            || self.missing_counter != analysis.missing.counter()
+            || self.captures_counter != analysis.captures.counter()
+    }
+
+    fn apply(&self, analysis: &mut Analysis) -> bool {
+        let mut progress = false;
+
+        for color in ALL_COLORS {
+            let mut tombs = vec![];
+            // we init an array of length 64 in order to be able to call k-groups, the i-th
+            // position in the array represents the candidate opponent pieces that may have
+            // been captured in the i-th tomb
+            let mut captured_candidates = [EMPTY; 64];
+            for origin in COLOR_ORIGINS[color.to_index()] {
+                for tomb in analysis.captures(origin) {
+                    captured_candidates[tombs.len()] =
+                        missing_with_target_as_candidate_destiny(analysis, !color, tomb);
+                    tombs.push(tomb);
+                }
+            }
+
+            // if a tomb cannot be reached by a single candidate, the position is illegal
+            for candidates in captured_candidates.iter().take(tombs.len()) {
+                if *candidates == EMPTY {
+                    analysis.result = Some(Legality::Illegal)
+                }
+            }
+
+            // before applying the k-groups analysis, we combine the tombs with on-the-board
+            // pieces (characterized by their current square location) whose origins are
+            // included in the set of candidate missing pieces
+            let mut finals = tombs;
+            let mut origins_of_finals = captured_candidates;
+            for square in *analysis.board.color_combined(!color) {
+                // if all the candidate origins of the piece on square are candidate missing,
+                // add a new entry to finals
+                if analysis.origins(square) & analysis.missing(!color).set_candidates()
+                    == analysis.origins(square)
+                {
+                    origins_of_finals[finals.len()] = analysis.origins(square);
+                    finals.push(square);
+                }
+            }
+
+            for k in 1..finals.len() {
+                let mut iter = init_iter(finals.len());
+                loop {
+                    match find_k_group(k, &origins_of_finals, iter) {
+                        None => break,
+                        Some((group, remaining)) => {
+                            let group_indices = iter & !remaining;
+                            iter = remaining;
+
+                            // the destinies of the k-group are now clear
+                            let group_destinies = group_indices.fold(EMPTY, |acc, idx| {
+                                acc | BitBoard::from_square(finals[idx.to_index()])
+                            });
+                            for square in group {
+                                progress |= analysis.update_destinies(square, group_destinies)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        progress
+    }
+}
+
+/// A `BitBoard` encoding the starting square of all the missing pieces of the
+/// given color whose destiny may have been the given square.
+fn missing_with_target_as_candidate_destiny(
+    analysis: &Analysis,
+    color: Color,
+    target: Square,
+) -> BitBoard {
+    let mut candidates = EMPTY;
+    // TODO: we could be more precise and treat the certainly missing differently
+    // from the candidate missing
+    for origin in analysis.missing(color).all() {
+        if BitBoard::from_square(target) & analysis.destinies(origin) != EMPTY {
+            candidates |= BitBoard::from_square(origin)
+        }
+    }
+    candidates
+}
+
+/// A `BitBoard` including all the squares in the range 0..n.
+fn init_iter(n: usize) -> BitBoard {
+    let mut iter = EMPTY;
+    for i in 0..n {
+        iter |= BitBoard(1 << i as u64);
+    }
+    iter
+}

--- a/src/utils/chess_utils.rs
+++ b/src/utils/chess_utils.rs
@@ -2,7 +2,7 @@
 
 use chess::{
     get_bishop_rays, get_file, get_king_moves, get_knight_moves, get_pawn_attacks, get_pawn_quiets,
-    get_rank, get_rook_rays, BitBoard, Board, Color, Piece, Square, EMPTY,
+    get_rank, get_rook_rays, BitBoard, Board, Color, Piece, Rank, Square, EMPTY,
 };
 
 use super::LIGHT_SQUARES;
@@ -50,6 +50,14 @@ pub fn square_color(square: Square) -> Color {
     match BitBoard::from_square(square) & LIGHT_SQUARES {
         EMPTY => Color::Black,
         _ => Color::White,
+    }
+}
+
+pub fn origin_color(origin: Square) -> Color {
+    match origin.get_rank() {
+        Rank::First | Rank::Second => Color::White,
+        Rank::Seventh | Rank::Eighth => Color::White,
+        _ => panic!("Not an origin square"),
     }
 }
 
@@ -102,6 +110,21 @@ pub fn checking_predecessors(piece: Piece, color: Color, square: Square) -> BitB
         predecessors &= !get_file(square.get_file());
     }
     predecessors
+}
+
+/// Returns `Some piece` iff all the given squares contain a piece of type
+/// `piece`. Returns `None` otherwise.
+pub fn common_piece_in_all_squares(board: &Board, squares: BitBoard) -> Option<Piece> {
+    if squares == EMPTY {
+        return None;
+    }
+    let piece_opt = board.piece_on(squares.to_square());
+    for square in squares {
+        if board.piece_on(square) != piece_opt {
+            return None;
+        }
+    }
+    piece_opt
 }
 
 #[cfg(test)]

--- a/src/utils/k_groups.rs
+++ b/src/utils/k_groups.rs
@@ -7,9 +7,9 @@
 use chess::{BitBoard, EMPTY};
 
 /// On input `k`, an array of sets (64 sets, one for each square on the board)
-/// and a set of (square) indices given in the form of `BitBoard`, this function
-/// finds a `k`-group and returns its union set and a set of the indices that
-/// *do not* form the k-group.
+/// and a set of `Square`-indices given in the form of `BitBoard`, this
+/// function finds a `k`-group and returns its union set and a set of the
+/// indices that *do not* form the k-group.
 ///
 /// This function returns `None` iff no k-group exists in the given sets
 /// filtered by the given indices.

--- a/src/utils/uncertain_sets.rs
+++ b/src/utils/uncertain_sets.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use chess::{BitBoard, EMPTY};
+use chess::{BitBoard, Square, EMPTY};
 
 #[derive(Debug, Clone, Copy)]
 pub struct UncertainSet {
@@ -19,6 +19,21 @@ impl UncertainSet {
             certain: EMPTY,
             candidates: !EMPTY,
         }
+    }
+
+    /// The size of Self.
+    #[allow(dead_code)]
+    pub fn size(&self) -> u32 {
+        self.size
+    }
+
+    #[allow(dead_code)]
+    pub fn certainly_in_the_set(&self) -> BitBoard {
+        self.certain
+    }
+
+    pub fn set_candidates(&self) -> BitBoard {
+        self.candidates
     }
 
     /// Adds the given elements to Self.
@@ -44,6 +59,16 @@ impl UncertainSet {
         self.candidates = new_candidates;
         self.simplify();
         true
+    }
+
+    /// All the elements potentially in the set, including all the candidates.
+    pub fn all(&self) -> BitBoard {
+        self.certain | self.candidates
+    }
+
+    /// Check is the given square is certainly in the Self.
+    pub fn mem(&self, square: Square) -> bool {
+        BitBoard::from_square(square) & self.certain != EMPTY
     }
 
     fn simplify(&mut self) {


### PR DESCRIPTION
We make sure that all the squares where we know captures took place can be reached by some of the opponent missing pieces.