### PR TITLE
Fix 2 bugs related to knights

### DIFF
--- a/src/rules/steady.rs
+++ b/src/rules/steady.rs
@@ -7,7 +7,7 @@
 //! pawns on their relative 2nd rank are steady, thus a white bishop on c1 is
 //! steady if there are white pawns on b2 and d2).
 
-use chess::{get_rank, BitBoard, CastleRights, Piece, ALL_COLORS};
+use chess::{get_rank, BitBoard, CastleRights, Piece, ALL_COLORS, EMPTY};
 
 use super::{Analysis, Rule, QUEEN_ORIGINS};
 use crate::{rules::COLOR_ORIGINS, utils::predecessors, RetractableBoard};
@@ -80,7 +80,12 @@ fn steady_pieces(board: &RetractableBoard, steady: &BitBoard) -> BitBoard {
         // a king-queen couple surrounded by steady pieces must be steady
         let couple = MARRIAGE_COUPLE[color.to_index()];
         let cage = MARRIAGE_CAGE[color.to_index()];
-        if (cage & steady) == cage && (couple & board.color_combined(color)) == couple {
+        // Knights are the only piece that can jump into the cage. Instead of checking
+        // that there is a queen and a king, we can simply check there are no knights.
+        if (cage & steady) == cage
+            && (couple & board.color_combined(color)) == couple
+            && couple & board.pieces(Piece::Knight) == EMPTY
+        {
             steady |= couple;
         }
     }

--- a/tests/legality.rs
+++ b/tests/legality.rs
@@ -54,6 +54,7 @@ fn test_legality_misc() {
         ("rnb1kb2/pppppppr/7p/8/8/P5PP/1PPPP1PR/RNB1KB2 w Qq -", Legal),
         ("Nrq1kb1r/pppppppp/1N6/8/1P6/4n1n1/1PPPPPPP/R1BQKB1R b KQk -", Illegal),
         ("r1bnkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq -", Legal),
+        ("rnbqkbnr/1pppppp1/1N5p/1p6/8/8/PPPPPPPP/R1BQKB1R w KQkq -", Legal),
 
         ("r1bqk2r/1pppp1p1/8/5pN1/2Q4p/PP5n/pBPPPPPP/N3K1nR w Kkq -", Illegal),
 

--- a/tests/legality.rs
+++ b/tests/legality.rs
@@ -53,6 +53,7 @@ fn test_legality_misc() {
         ("rnb1kb2/pppppppr/7p/8/8/P5PP/1PPPP1PR/RNB1KBN1 b Qq -", Legal),
         ("rnb1kb2/pppppppr/7p/8/8/P5PP/1PPPP1PR/RNB1KB2 w Qq -", Legal),
         ("Nrq1kb1r/pppppppp/1N6/8/1P6/4n1n1/1PPPPPPP/R1BQKB1R b KQk -", Illegal),
+        ("r1bnkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq -", Legal),
 
         ("r1bqk2r/1pppp1p1/8/5pN1/2Q4p/PP5n/pBPPPPPP/N3K1nR w Kkq -", Illegal),
 


### PR DESCRIPTION
- The "cage" rule for steady pieces was not checking (and is still not checking) that the pieces in the cage were a king and a queen. This is fine as long as we check that there are no knights on the cage, the only piece that can jump inside. We added this check and a test case for it.

- The parity rule for deciding whether the parity on the number of knight moves was not completely correct. The reason is that we were checking "destinies" assuming that they contain all actual targets. However, "destinies" is a candidate set of destinies, not certain. In order to address this issue, we introduced a field called "knights_parity" which can be properly updated inside the "tombs" rule.