### PR TITLE
Improvements on pawn origins & forced captures

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,23 @@
+name: examples
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run all examples
+      run: |
+        for example in $(ls examples); do
+          cargo run --release --example ${example%.*}
+        done

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://github.com/miguel-ambrona/sherlock-rust/actions/workflows/rust-ci.yml/badge.svg)](https://github.com/miguel-ambrona/sherlock-rust/actions/workflows/rust-ci.yml)
 [![Documentation](https://github.com/miguel-ambrona/sherlock-rust/actions/workflows/rust-docs.yml/badge.svg)](https://github.com/miguel-ambrona/sherlock-rust/actions/workflows/rust-docs.yml)
+[![Examples](https://github.com/miguel-ambrona/sherlock-rust/actions/workflows/examples.yml/badge.svg)](https://github.com/miguel-ambrona/sherlock-rust/actions/workflows/examples.yml)
 
 # Sherlock
 
@@ -27,7 +28,7 @@ Thank you both! :heart:
  Consider the following position where en-passant is possible on d3
  and all castling rights are still available:
 
-![Example](https://backscattering.de/web-boardimage/board.svg?fen=r1bqkb1r/ppppp1pp/8/8/2pP4/8/1PP1PPPP/R1BQKB1R&arrows=Bd2d4&coordinates=true&size=300&colors=lichess-blue)
+![Example](https://backscattering.de/web-boardimage/board.svg?fen=r1bqkb1r/ppppp1pp/8/8/2pP4/8/1PP1PPPP/R1BQKB1R&arrows=Bd2d4&coordinates=true&size=300)
 
 It turns out to be illegal!<br><br>
 

--- a/README.md
+++ b/README.md
@@ -9,22 +9,26 @@ A chess library written in Rust, oriented to creating and solving chess
 compositions with especial emphasis on retrograde analysis.
 
 This library's name is inspired by *"The Chess Mysteries of Sherlock Holmes"*,
-a master piece on retrograde analysis by the great Raymond Smullyan.
+a master piece on retrograde analysis by the great Raymond M. Smullyan.
 
 We rely on [jordanbray/chess](https://crates.io/crates/chess), an amazing
-Rust chess library for very efficient move generation.
+Rust chess library, by [Jordan Bray](https://github.com/jordanbray), for very
+efficient move generation.
+The images in this README and our documentation are rendered with
+[web-boardimage](https://github.com/niklasf/web-boardimage), an HTTP service
+developed and offered by [Niklas Fiekas](https://github.com/niklasf).
+Thank you both! :heart:
+
 
 ## Examples
 
 ### Check the legality of a position
 
- <details open>
- <summary>Consider the following position where en-passant is possible on d3
- and all castling rights are still available:<br><br></summary>
+ Consider the following position where en-passant is possible on d3
+ and all castling rights are still available:
 
-![Example](https://backscattering.de/web-boardimage/board.svg?fen=r1bqkb1r/ppppp1pp/8/8/2pP4/8/1PP1PPPP/R1BQKB1R&arrows=Bd2d4)
+![Example](https://backscattering.de/web-boardimage/board.svg?fen=r1bqkb1r/ppppp1pp/8/8/2pP4/8/1PP1PPPP/R1BQKB1R&arrows=Bd2d4&coordinates=true&size=300&colors=lichess-blue)
 
-</details>
 It turns out to be illegal!<br><br>
 
 <details>
@@ -50,13 +54,41 @@ Sherlock can realize this.<br><br>
 
 ```rust
 use chess::Board;
-use sherlock::is_legal;
 use std::str::FromStr;
 
 let board = Board::from_str("r1bqkb1r/ppppp1pp/8/8/2pP4/8/1PP1PPPP/R1BQKB1R b KQkq d3").unwrap();
-assert_eq!(is_legal(&board), false);
+assert_eq!(sherlock::is_legal(&board), false);
 
 // the same position with en-passant disabled would be legal
 let board = Board::from_str("r1bqkb1r/ppppp1pp/8/8/2pP4/8/1PP1PPPP/R1BQKB1R b KQkq -").unwrap();
-assert_eq!(is_legal(&board), true);
+assert_eq!(sherlock::is_legal(&board), true);
+```
+
+### The Mystery of the Missing Piece
+
+This is a composition by Raymond M. Smullyan from the above-mentioned book.
+On h4 rests a shilling instead of a chess piece. The challenge is to determine
+what piece it is.
+
+![Example](https://backscattering.de/web-boardimage/board.svg?fen=2nR3K/pk1Rp1p1/p2p4/P1p5/1Pp5/2PP2P1/4P2P/n7&squares=h4&coordinates=true&size=300&colors=wikipedia)
+
+Sherlock can realize that the shilling must be a *white bishop*
+(refer to the book for an explanation):
+
+```rust
+use chess::{Board, Color::White, Piece::Bishop, Square};
+use std::str::FromStr;
+use sherlock::{is_legal, ALL_COLORED_PIECES};
+
+let board = Board::from_str("2nR3K/pk1Rp1p1/p2p4/P1p5/1Pp5/2PP2P1/4P2P/n7 b - -").unwrap();
+
+// all the pieces that lead to a legal position when placed on h4
+let valid_pieces: Vec<_> = ALL_COLORED_PIECES
+    .into_iter()
+    .filter(|&(color, piece)| {
+        board.set_piece(piece, color, Square::H4).as_ref().map_or(false, is_legal)
+    })
+    .collect();
+
+assert_eq!(valid_pieces, vec![(White, Bishop)]);
 ```

--- a/examples/indiant_chess_set.rs
+++ b/examples/indiant_chess_set.rs
@@ -1,0 +1,20 @@
+//! This example includes a problem by Raymond M. Smullyan, from the book
+//! "The Chess Mysteries of Sherlock Holmes".
+//! See Chapter "The Mystery of the Indiant Chess Set".
+
+use std::str::FromStr;
+
+use chess::Board;
+use sherlock::is_legal;
+
+fn main() {
+    let board_from_white =
+        Board::from_str("r1b1kb1r/pppppppp/2N5/5n2/6N1/2n5/PPPPPPPP/1RBK1B1R w - -").unwrap();
+
+    assert!(!is_legal(&board_from_white));
+
+    let board_from_black =
+        Board::from_str("r1b1kbr1/pppppppp/5N2/1n6/2N5/5n2/PPPPPPPP/R1BK1B1R b - -").unwrap();
+
+    assert!(is_legal(&board_from_black));
+}

--- a/examples/missing_piece.rs
+++ b/examples/missing_piece.rs
@@ -1,0 +1,26 @@
+//! This example corresponds to a problem by Raymond M. Smullyan, from the book
+//! "The Chess Mysteries of Sherlock Holmes".
+//! See Chapter "Mystery of the Missing Piece".
+
+use std::str::FromStr;
+
+use chess::{Board, Color::White, Piece::Bishop, Square};
+use sherlock::{is_legal, ALL_COLORED_PIECES};
+
+fn main() {
+    let board = Board::from_str("2nR3K/pk1Rp1p1/p2p4/P1p5/1Pp5/2PP2P1/4P2P/n7 b - -").unwrap();
+
+    // all the pieces that can be placed on h4 leading to a legal position
+    let valid_pieces: Vec<_> = ALL_COLORED_PIECES
+        .into_iter()
+        .filter(|&(color, piece)| {
+            #[allow(deprecated)]
+            board
+                .set_piece(piece, color, Square::H4)
+                .as_ref()
+                .map_or(false, is_legal)
+        })
+        .collect();
+
+    assert_eq!(valid_pieces, vec![(White, Bishop)]);
+}

--- a/examples/two_bagatelles.rs
+++ b/examples/two_bagatelles.rs
@@ -1,0 +1,27 @@
+//! This example includes a problem by Raymond M. Smullyan, from the book
+//! "The Chess Mysteries of Sherlock Holmes". See Chapter "Two Bagatelles".
+
+use std::str::FromStr;
+
+use chess::{Board, CastleRights, Color::Black, ALL_CASTLE_RIGHTS};
+use sherlock::is_legal;
+
+fn main() {
+    let board = Board::from_str("r1b1k2r/p1p1p1pp/1p3p2/8/8/P7/1PPPPPPP/2BQKB2 b - -").unwrap();
+
+    // all the castle rights (for Black) under which the position is legal
+    let valid_castling_rights: Vec<_> = ALL_CASTLE_RIGHTS
+        .into_iter()
+        .filter(|&castling_rights| {
+            let mut board_copy = board;
+            #[allow(deprecated)]
+            board_copy.add_castle_rights(Black, castling_rights);
+            is_legal(&board_copy)
+        })
+        .collect();
+
+    assert_eq!(
+        valid_castling_rights,
+        vec![CastleRights::NoRights, CastleRights::QueenSide]
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ mod retractor;
 mod rules;
 mod utils;
 
-pub use crate::{analysis::*, legality::*, retractor::*};
+pub use crate::{analysis::*, legality::*, retractor::*, utils::ALL_COLORED_PIECES};
 
 #[doc = include_str!("../README.md")]
 

--- a/src/rules/mobility.rs
+++ b/src/rules/mobility.rs
@@ -90,7 +90,7 @@ impl Rule for MobilityRule {
                         continue;
                     }
                     let forced = analysis.mobility.value[color.to_index()][Piece::Pawn.to_index()]
-                        .forced_captures(square, target);
+                        .forced_captures(square, target, nb_allowed_captures);
                     progress |= analysis.update_pawn_forced_captures(color, file, target, forced);
                 }
             }

--- a/src/rules/route_from_origins.rs
+++ b/src/rules/route_from_origins.rs
@@ -16,6 +16,7 @@ pub struct RouteFromOriginsRule {
     reachable_from_promotion_counter: usize,
     nb_captures_counter: usize,
     steady_counter: usize,
+    origins_counter: usize,
 }
 
 impl Rule for RouteFromOriginsRule {
@@ -26,6 +27,7 @@ impl Rule for RouteFromOriginsRule {
             reachable_from_promotion_counter: 0,
             nb_captures_counter: 0,
             steady_counter: 0,
+            origins_counter: 0,
         }
     }
 
@@ -35,6 +37,7 @@ impl Rule for RouteFromOriginsRule {
         self.reachable_from_promotion_counter = analysis.reachable_from_promotion.counter();
         self.nb_captures_counter = analysis.nb_captures.counter();
         self.steady_counter = analysis.steady.counter();
+        self.origins_counter = analysis.origins.counter();
     }
 
     fn is_applicable(&self, analysis: &Analysis) -> bool {
@@ -43,6 +46,7 @@ impl Rule for RouteFromOriginsRule {
             || self.reachable_from_promotion_counter != analysis.reachable_from_promotion.counter()
             || self.nb_captures_counter != analysis.nb_captures.counter()
             || self.steady_counter != analysis.steady.counter()
+            || self.origins_counter != analysis.origins.counter()
     }
 
     fn apply(&self, analysis: &mut Analysis) -> bool {

--- a/src/utils/chess_utils.rs
+++ b/src/utils/chess_utils.rs
@@ -9,6 +9,23 @@ use chess::{
 use super::LIGHT_SQUARES;
 use crate::RetractableBoard;
 
+/// An array representing all 12 different (colored) pieces, each consisting of
+/// a pair including their color and their piece type.
+pub const ALL_COLORED_PIECES: [(Color, Piece); 12] = [
+    (Color::White, Piece::Pawn),
+    (Color::White, Piece::Knight),
+    (Color::White, Piece::Bishop),
+    (Color::White, Piece::Rook),
+    (Color::White, Piece::Queen),
+    (Color::White, Piece::King),
+    (Color::Black, Piece::Pawn),
+    (Color::Black, Piece::Knight),
+    (Color::Black, Piece::Bishop),
+    (Color::Black, Piece::Rook),
+    (Color::Black, Piece::Queen),
+    (Color::Black, Piece::King),
+];
+
 /// Construct a `BitBoard` out of the given squares.
 #[cfg(test)]
 pub(crate) fn bitboard_of_squares(squares: &[Square]) -> BitBoard {

--- a/tests/legality.rs
+++ b/tests/legality.rs
@@ -92,6 +92,10 @@ fn test_legality_misc() {
         ("Knrk4/BpppRp2/1p2p3/8/8/8/8/8 b - -", Illegal),
         ("Knrk4/BpppRp2/1p2p3/8/8/8/8/8 w - -", TBD),
         ("KBrk4/1pppRp2/1p2p3/8/8/8/8/8 b - -", TBD),
+
+        // Smullyan
+        ("2nb3K/pkPRp1p1/p2p4/P1p5/1Pp4Q/2PP2P1/4P2P/n7 w - -", Illegal),
+        ("2nb3K/pkPRp1p1/p2p4/P1p5/1Pp4B/2PP2P1/4P2P/n7 w - -", Legal),
     ];
     test_legality(&positions)
 }


### PR DESCRIPTION
- If we find a 2-group of 2 pawns, we may be able to determine their origins if one of the 2 possibilities requires too many captures.
- We add a new argument "allow_nb_captures" to the forced captures analysis.